### PR TITLE
Updating household GAMS files

### DIFF
--- a/household/build.gms
+++ b/household/build.gms
@@ -27,7 +27,7 @@ $if not set capital_ownership $set capital_ownership "all"
 * set regional mapping (state,census_divisions,census_regions,national)
 $if not set rmap $set rmap "state"
 
-* set sectoral mapping (windc,gtap_32,sage,gtap_10,macro,bluenote)
+* set sectoral mapping (windc,gtap_32,gtap_10,macro,bluenote)
 $if not set smap $set smap "windc,gtap_32"
 
 

--- a/household/build.gms
+++ b/household/build.gms
@@ -12,7 +12,7 @@ $title Build routine for the windc household dataset
 * Set options
 * ------------------------------------------------------------------------------
 
-* set year(s) to compute data (cps: 2000-2022, soi: 2014-2017)
+* set year(s) to compute data (cps: 2000-2023, soi: 2014-2017)
 $if not set year $set year "2023"
 
 * set household data (cps, soi)

--- a/household/build.gms
+++ b/household/build.gms
@@ -13,7 +13,7 @@ $title Build routine for the windc household dataset
 * ------------------------------------------------------------------------------
 
 * set year(s) to compute data (cps: 2000-2023, soi: 2014-2017)
-$if not set year $set year "2023"
+$if not set year $set year "2017,2023"
 
 * set household data (cps, soi)
 $if not set hhdata $set hhdata "cps"

--- a/household/build.gms
+++ b/household/build.gms
@@ -13,7 +13,7 @@ $title Build routine for the windc household dataset
 * ------------------------------------------------------------------------------
 
 * set year(s) to compute data (cps: 2000-2022, soi: 2014-2017)
-$if not set year $set year "2017,2022"
+$if not set year $set year "2023"
 
 * set household data (cps, soi)
 $if not set hhdata $set hhdata "cps"

--- a/household/cps_data.gms
+++ b/household/cps_data.gms
@@ -23,13 +23,13 @@ $set gdxdir gdx/
 
 * Translate the CPS income CSV data to GDX:
 
-$set file "%cpsdir%cps_asec_income_totals_2000_2022.csv"
+$set file "%cpsdir%cps_asec_income_totals.csv"
 $if not exist %file% $abort "%file% does not exist. Did you place the data in the correct location?"
 $call 'csv2gdx "%file%" id=cpscsv useheader=yes index="(1,2,3,4)" values=5 output="%gdxdir%cpscsv.gdx" CheckDate=yes trace=3'
 
 * Translate the CPS population CSV data to GDX:
 
-$set file "%cpsdir%cps_asec_numberhh_2000_2022.csv"
+$set file "%cpsdir%cps_asec_numberhh.csv"
 $if not exist %file% $abort "%file% does not exist. Did you place the data in the correct location?"
 $call 'csv2gdx %file% id=popcsv useheader=yes index="(1,2,3)" values=4 output="%gdxdir%cps_households.gdx" CheckDate=yes trace=3'
 
@@ -151,7 +151,8 @@ set
 			hfinval	! "financial assistance"
 			) /;
 
-r(sr) = yes$(not sameas(sr,'us'));
+*r(sr) = yes$(not sameas(sr,'us'));
+r(sr) = yes;
 
 parameter
     wages0_(yr,sr,h)		Wage income by region and household (in billions),

--- a/household/hhcalib.gms
+++ b/household/hhcalib.gms
@@ -1033,6 +1033,7 @@ fsav0 = FSAV.L;
 fint0 = FINT.L;
 
 $if %hhdata%=="soi" hhtrn0(r,h,'gov') = TRANS_GOV.L(r,h);
+$if %hhdata%=="soi" trn('gov') = yes;
 $if %hhdata%=="cps" hhtrn0(r,h,trn) = hhtrans_shr(r,h,trn) * TRANS_GOV.L(r,h);
 
 trn('other') = yes;

--- a/household/hhcalib.gms
+++ b/household/hhcalib.gms
@@ -329,8 +329,8 @@ $if %hhdata%=="cps" trn_weight_(yr,'hdisval','nipa')$(cps_nipa(yr,'government be
 $if %hhdata%=="cps" trn_weight_(yr,'hdisval','nipa')$(not cps_nipa(yr,'government benefits: social security')) = trn_weight_(yr,'hdisval','meyer');
 
 $if %hhdata%=="cps" trn_weight_(yr,'hvetval','rothbaum') = 1 / 0.679;
-$if %hhdata%=="cps" trn_weight_(yr,'hvetrval','nipa')$(cps_nipa(yr,"government benefits: veterans' benefits")) = 1 / (cps_nipa(yr,"government benefits: veterans' benefits")/100 + 1);
-$if %hhdata%=="cps" trn_weight_(yr,'hvetrval','nipa')$(not cps_nipa(yr,"government benefits: veterans' benefits")) = trn_weight_(yr,'hvetrval','rothbaum');
+$if %hhdata%=="cps" trn_weight_(yr,'hvetrval','nipa')$(cps_nipa(yr,"government benefits: veterans benefits")) = 1 / (cps_nipa(yr,"government benefits: veterans benefits")/100 + 1);
+$if %hhdata%=="cps" trn_weight_(yr,'hvetrval','nipa')$(not cps_nipa(yr,"government benefits: veterans benefits")) = trn_weight_(yr,'hvetrval','rothbaum');
 
 * Otherwise, default to literature estimates
 
@@ -378,7 +378,7 @@ parameter
     health_care_transfers(r,*,*,*)	Medicaid and medicare transfers payments;
 
 $set health_data_dir ../data/household/health_care/
-$set file "%health_data_dir%public_health_benefits_2009_2019.csv"
+$set file "%health_data_dir%public_health_benefits.csv"
 $call 'csv2gdx "%file%" id=health_care_transfers useheader=yes index="(1,2,3)" values="(4,5)" output="%gdxdir%public_health_benefits.gdx"'
 $gdxin '%gdxdir%public_health_benefits.gdx'
 $load health_care_transfers

--- a/household/soi_data.gms
+++ b/household/soi_data.gms
@@ -21,7 +21,7 @@ $set gdxdir gdx/
 
 * Translate the SOI income CSV data to GDX:
 
-$set file "%soidir%soi_income_totals_2014_2017.csv"
+$set file "%soidir%soi_income_totals.csv"
 $if not exist %file% $abort "%file% does not exist. Did you place the data in the correct location?"
 $call 'csv2gdx "%file%" id=soicsv useheader=yes index="(1,2,3,4)" values=5 output="%gdxdir%soicsv.gdx" CheckDate=yes trace=3'
 
@@ -153,7 +153,7 @@ set
 * 60b First-time homebuyer credit repayment. Attach Form 5405 if required -- missing
 * 62c Taxes from Instructions -- missing
 		
-		fed_tax.a10300 ! Total tax liability amount [8] 1040:63 / 1040A:39 / 1040EZ: 10"
+		fed_tax.a10300 ! Total tax liability amount [8] 1040:63 / 1040A:39 / 1040EZ: 10
 
 		retirement.(
 			a03300	! Self-employment retirement plans amount 1040:28
@@ -210,7 +210,7 @@ display fedtax;
 set
     h		Household categories /
                 hh1      "under $25,000",
-		hh2      "$25,000 under $50,000",
+				hh2      "$25,000 under $50,000",
                 hh3      "$50,000 under $75,000",
                 hh4      "$75,000 under $200,000",
                 hh5      "over $200,000" /,

--- a/household/static_model.gms
+++ b/household/static_model.gms
@@ -6,7 +6,7 @@ $title Static household model (MGE and MCP)
 * -----------------------------------------------------------------------------
 
 * Set datset option
-$set ds cps_static_all_2022
+$set ds cps_static_all_2023_gtap_32_state
 
 * Allow for end of line comments
 $eolcom !

--- a/tests/Manifest.toml
+++ b/tests/Manifest.toml
@@ -1,0 +1,242 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.3"
+manifest_format = "2.0"
+project_hash = "061b0944c0a20971d6f7ce62009e5a990fdb3437"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.16.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
+
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataFrames]]
+deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "fb61b4812c49343d7ef0b533ba982c46021938a6"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.7.0"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.20"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
+
+[[deps.InlineStrings]]
+git-tree-sha1 = "6a9fde685a7ac1eb3495f8e812c5a7c3711c2d5e"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.4.3"
+
+    [deps.InlineStrings.extensions]
+    ArrowTypesExt = "ArrowTypes"
+    ParsersExt = "Parsers"
+
+    [deps.InlineStrings.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+    Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.InvertedIndices]]
+git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.3.1"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.LaTeXStrings]]
+git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.4.0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.27+1"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "cc4054e898b852042d7b503313f7ad03de99c3dd"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.0"
+
+[[deps.PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "36d8b4b899628fb92c2749eb488d884a926614d3"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.4.3"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.PrettyTables]]
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "1101cd475833706e4d0e7b122218257178f48f34"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "2.4.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "712fb0231ee6f9120e005ccd56297abbc053e7e0"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.4.8"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "66e0a8e672a0bdfca2c3f5937efb8538b9ddc085"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.1"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StringManipulation]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "725421ae8e530ec29bcbdddbe91ff8053421d023"
+uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
+version = "0.4.1"
+
+[[deps.Suppressor]]
+deps = ["Logging"]
+git-tree-sha1 = "6dbb5b635c5437c68c28c2ac9e39b87138f37c0a"
+uuid = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+version = "0.2.8"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "598cd7c1f68d1e205689b1c2fe65a9f85846f297"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.12.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"

--- a/tests/Project.toml
+++ b/tests/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"

--- a/tests/household.jl
+++ b/tests/household.jl
@@ -1,0 +1,70 @@
+using Suppressor
+
+function set_working_directory()
+    path = split(pwd(), "\\")
+
+    if path[end] == "household"
+        return true
+    end
+
+    if path[end] == "windc_build"
+        cd("household")
+        return true
+    end
+
+    return false
+    
+end
+
+function run_household(year, household, invest, capital, region, sector)
+    set_working_directory()
+    @suppress run(`gams build.gms --hhdata $household --year $year --invest $invest --capital_ownership $capital --rmap $region --smap $sector`)
+end
+
+
+
+function test_household()
+    set_working_directory()
+
+    log_file = "household.log"
+
+    #if isfile(log_file)
+    #    rm(log_file)
+    #end
+    touch(log_file)
+
+    cps_years = 2000:2023
+    soi_years = 2014:2017
+    investments = ["static", "dynamic"]
+    capital_ownership = ["all", "partial"]
+    regoinal_mapping = ["state", "census_divisions", "census_regions", "national"]
+    sectoral_mapping = ["windc", "gtap_32", "sage", "gtap_10", "macro", "bluenote"]
+
+    #=
+    for (y,i,c,r,s) in Iterators.product(cps_years, investments, capital_ownership, regoinal_mapping, sectoral_mapping) 
+        println("CPS - $y $i $c $r $s")
+        try
+            run_household(y, "cps", i, c, r, s)
+        catch e
+            open(log_file, "a") do io
+                write(io, "CPS - $y $i $c $r $s\n")
+            end
+        end
+    end
+    =#
+
+    for (y,i,c,r,s) in Iterators.product(soi_years, investments, capital_ownership, regoinal_mapping, sectoral_mapping) 
+        println("SOI - $y $i $c $r $s")
+        try
+            run_household(y, "soi", i, c, r, s)
+        catch e
+            open(log_file, "a") do io
+                write(io, "SOI - $y $i $c $r $s\n")
+            end
+        end
+    end
+
+end
+
+
+test_household()

--- a/tests/household.jl
+++ b/tests/household.jl
@@ -22,6 +22,18 @@ function run_household(year, household, invest, capital, region, sector)
 end
 
 
+function test_household_instance(year, household, invest, capital, region, sector)
+    output = "$household - $year, $invest, $capital, $region, $sector"
+    println(output)
+    try
+        run_household(y, household, i, c, r, s)
+    catch e
+        open(log_file, "a") do io
+            write(io, "$output\n")
+        end
+    end
+end
+
 
 function test_household()
     set_working_directory()
@@ -40,28 +52,14 @@ function test_household()
     regoinal_mapping = ["state", "census_divisions", "census_regions", "national"]
     sectoral_mapping = ["windc", "gtap_32", "sage", "gtap_10", "macro", "bluenote"]
 
-    #=
+    
     for (y,i,c,r,s) in Iterators.product(cps_years, investments, capital_ownership, regoinal_mapping, sectoral_mapping) 
-        println("CPS - $y $i $c $r $s")
-        try
-            run_household(y, "cps", i, c, r, s)
-        catch e
-            open(log_file, "a") do io
-                write(io, "CPS - $y $i $c $r $s\n")
-            end
-        end
+        test_household_instance(y, "cps", i, c, r, s)
     end
-    =#
+    
 
     for (y,i,c,r,s) in Iterators.product(soi_years, investments, capital_ownership, regoinal_mapping, sectoral_mapping) 
-        println("SOI - $y $i $c $r $s")
-        try
-            run_household(y, "soi", i, c, r, s)
-        catch e
-            open(log_file, "a") do io
-                write(io, "SOI - $y $i $c $r $s\n")
-            end
-        end
+        test_household_instance(y, "soi", i, c, r, s)
     end
 
 end


### PR DESCRIPTION
Several household data files have explicit year references in their file names. This branch removes references to the years. This should make the data easier to update each year.

Additionally, removed `US` from raw data which removes the need for the `sr` set, which includes `US`. We don't remove the `sr` set, but modify the line

`r(sr) = yes$(sameas(sr, "US")`

to be

`r(sr) = yes`

to set these to be the same. May replace with an alias or remove `sr`.